### PR TITLE
fix: return wrong cpu core number and deps

### DIFF
--- a/deps/build_deps.sh
+++ b/deps/build_deps.sh
@@ -39,6 +39,9 @@ git submodule update
 
 cd ${BPFTOOL_SRC_DIR}
 
+git submodule init
+git submodule update
+
 make clean &> ${BUILD_LOGS}/bpftool.log
 make &>> ${BUILD_LOGS}/bpftool.log
 RETVAL=$?
@@ -113,6 +116,9 @@ fi
 echo "  Compiling capstone..."
 
 cd ${CAPSTONE_SRC_DIR}
+
+git submodule init
+git submodule update
 
 make clean &> ${BUILD_LOGS}/capstone.log
 CAPSTONE_ARCHS="arm aarch64 x86" ./make.sh &> ${BUILD_LOGS}/capstone.log

--- a/src/setup_bpf.h
+++ b/src/setup_bpf.h
@@ -11,6 +11,7 @@
 #include <bpf/bpf.h>
 #include <linux/bpf.h>
 #include <sys/mman.h>
+#include <sys/sysinfo.h>
 
 #ifdef TMA
 #include "tma.h"
@@ -78,7 +79,7 @@ static int init_tma_bpf_info() {
     opts.btf_custom_path = pw_opts.btf_custom_path;
   }
   
-  bpf_info->nr_cpus = libbpf_num_possible_cpus();
+  bpf_info->nr_cpus = get_nprocs_conf();
   get_pmu_string(bpf_info->pmu_name);
   if(init_tma() < 0) {
     return -1;
@@ -256,7 +257,7 @@ static int init_insn_bpf_info() {
   }
 #endif
   
-  bpf_info->nr_cpus = libbpf_num_possible_cpus();
+  bpf_info->nr_cpus = get_nprocs_conf();
   return 0;
 }
 


### PR DESCRIPTION
1. Just found this issue on AMD EPYC 9654 and it seemed also related to the linux  kernel version.
2.  fix the deps issue when building in docker env
