### PR TITLE
ignore offline cpus

### DIFF
--- a/src/setup_bpf.h
+++ b/src/setup_bpf.h
@@ -216,6 +216,9 @@ static int program_events(int pid) {
   if(pid == -1) {
     for(cpu = 0; cpu < bpf_info->nr_cpus; cpu++) {
       retval = single_insn_event(cpu, pid);
+      if(retval == -2) { // cpu is offline
+        continue;
+      }
       if(retval < 0) {
         return -1;
       }


### PR DESCRIPTION
Currently when processwatch detects a CPU offline, it issues a warning: "WARNING: CPU xxx is offline." and then exits.

This PR intends to ignore CPUs that are offline, i.e., continue processing even if offline CPUs are detected.